### PR TITLE
Provide more info with error messages

### DIFF
--- a/lib/unresponsys/client.rb
+++ b/lib/unresponsys/client.rb
@@ -72,13 +72,13 @@ class Unresponsys
       if response.is_a?(Hash) && response.keys.include?('errorCode')
         case response['errorCode']
         when /TOKEN_EXPIRED/
-          raise Unresponsys::TokenExpired, response['detail']
+          raise Unresponsys::TokenExpired, format_error_message(response['title'], response['detail'])
         when /NOT_FOUND/
-          raise Unresponsys::NotFound, response['detail']
+          raise Unresponsys::NotFound, format_error_message(response['title'], response['detail'])
         when /LIMIT_EXCEEDED/
-          raise Unresponsys::LimitExceeded, response['detail']
+          raise Unresponsys::LimitExceeded, format_error_message(response['title'], response['detail'])
         else
-          raise Unresponsys::Error, "#{response['title']}: #{response['detail']}"
+          raise Unresponsys::Error, format_error_message(response['title'], response['detail'])
         end
       end
       response
@@ -94,6 +94,11 @@ class Unresponsys
 
       @options  = { headers: { 'Authorization' => response['authToken'], 'Content-Type' => 'application/json' } }
       @base_uri = "#{response['endPoint']}/rest/api/v1.1"
+    end
+
+    def format_error_message(title, detail)
+      return title if detail.to_s.strip.empty?
+      "#{title}: #{detail}"
     end
   end
 end

--- a/lib/unresponsys/errors.rb
+++ b/lib/unresponsys/errors.rb
@@ -1,6 +1,16 @@
 class Unresponsys
-  class ArgumentError < StandardError; end
-  class AuthenticationError < StandardError; end
+  class ArgumentError < StandardError
+    def initialize(msg="Wrong number of arguments")
+      super
+    end
+  end
+
+  class AuthenticationError < StandardError
+    def initialize(msg="Authentication error occurred")
+      super
+    end
+  end
+
   class Error < StandardError; end
   class NotFound < StandardError; end
   class LimitExceeded < StandardError; end

--- a/lib/unresponsys/version.rb
+++ b/lib/unresponsys/version.rb
@@ -1,3 +1,3 @@
 class Unresponsys
-  VERSION = '0.6'
+  VERSION = '0.7'
 end


### PR DESCRIPTION
The `response['detail']` that is passed into the error classes is sometimes blank, so the standard to_s or e.message doesn't provide any more info about the error.  Every error response from Responsys contains `title`, so it uses that and adds `detail` if it's available.
